### PR TITLE
Added ability to set prefix in constants.js file

### DIFF
--- a/src/x-saw-fa-icon-demo/components/fa-icon/constants.js
+++ b/src/x-saw-fa-icon-demo/components/fa-icon/constants.js
@@ -1,0 +1,3 @@
+//! Set this to change this component to whatever custom prefix you want
+//! eg: <nowcomponents-fa-icon />
+export const prefix = 'nowcomponents';

--- a/src/x-saw-fa-icon-demo/components/fa-icon/fa-icon.js
+++ b/src/x-saw-fa-icon-demo/components/fa-icon/fa-icon.js
@@ -5,14 +5,15 @@ import styles from './styles.scss';
 import view from './view';
 import actions from './actions';
 
-createCustomElement('fa-icon', {
+import { prefix } from './constants';
+
+const componentName = `${prefix && prefix != '' ? prefix.toLowerCase() + '-' : ''}fa-icon`;
+
+createCustomElement(componentName, {
 	renderer: { type: snabbdom },
 	view,
 	properties: {
 		def: {
-			default: null,
-		},
-		icon: {
 			default: null,
 		},
 		size: {
@@ -20,6 +21,9 @@ createCustomElement('fa-icon', {
 		},
 		spin: {
 			default: false,
+		},
+		componentId: {
+			default: null,
 		},
 	},
 	styles,

--- a/src/x-saw-fa-icon-demo/components/fa-icon/styles.scss
+++ b/src/x-saw-fa-icon-demo/components/fa-icon/styles.scss
@@ -1,6 +1,6 @@
 @import '@servicenow/sass-kit/host';
 
-:host(x-saw-fa-icon) {
+:host {
 	display: inline-flex;
 	font-size: $now-global-font-size--md;
 	color: inherit;

--- a/src/x-saw-fa-icon-demo/components/fa-icon/view.js
+++ b/src/x-saw-fa-icon-demo/components/fa-icon/view.js
@@ -6,7 +6,7 @@ export default (state, { updateProperties, dispatch }) => {
 	//┌─────────────────────────────────────────────────────────────
 	//! Scoped Constants
 	//└─────────────────────────────────────────────────────────────
-	const { icon: iconName, size, spin, def } = state.properties;
+	const { size, spin, def, componentId } = state.properties;
 	const BASE_FONT_SIZE = 16;
 	const ICON_SIZES = {
 		sm: 12,
@@ -15,46 +15,16 @@ export default (state, { updateProperties, dispatch }) => {
 		xl: 32,
 	};
 
-	const camelize = (str) => {
-		return str.replace(/^([A-Z])|[\s-_]+(\w)/g, function(match, p1, p2) {
-			return p2 ? p2.toUpperCase() : p1.toLowerCase();
-		});
-	};
-
-	const getAsyncIcon = () => {
-		try {
-			const formattedName = camelize(`fa-${iconName}`);
-			import(`@fortawesome/free-solid-svg-icons/${formattedName}`).then((module) => {
-				dispatch('SET_DEF', module.definition);
-			});
-
-			return;
-		} catch (e) {
-			return;
-		}
-	};
-
 	const getFaIcon = () => {
 		const wrapper = document.createElement('SPAN');
 		const iconSize = ICON_SIZES[size];
 		const iconRems = iconSize / BASE_FONT_SIZE;
-		const formattedName = camelize(`fa-${iconName}`);
 
-		if (!def && !iconName) {
+		if (!def) {
 			return null;
 		}
 
-		let localDef = {};
-
-		if (def) {
-			localDef = {
-				...def,
-			};
-		} else if (iconName) {
-			getAsyncIcon();
-		}
-
-		const { icon } = localDef;
+		const { icon } = def;
 
 		if (!icon) {
 			return null;
@@ -67,6 +37,7 @@ export default (state, { updateProperties, dispatch }) => {
 			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			viewBox="${viewBox}"
+			id="${componentId}"
 			style="width: ${iconRems}rem; height: ${iconRems}rem; fill: currentColor;"
 			${spin ? 'class="-spin"' : ''}>
 			<path xmlns="http://www.w3.org/2000/svg" d="${svgPathData}"></path>

--- a/src/x-saw-fa-icon-demo/constants.js
+++ b/src/x-saw-fa-icon-demo/constants.js
@@ -2,4 +2,4 @@ import { customAlphabet } from 'nanoid';
 
 export const getNanoID = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', 32);
 
-export const componentUniqueID = '@saleswon/fa-icon-demo';
+export const componentUniqueID = '@nowcomponents/fa-icon-demo';

--- a/src/x-saw-fa-icon-demo/view.js
+++ b/src/x-saw-fa-icon-demo/view.js
@@ -23,15 +23,7 @@ export default (state, { updateState, updateProperties, dispatch }) => {
 							return (
 								<div className="icon-container">
 									<div className="icon-body">
-										{idx % 2 === 0 ? (
-											//! You can either load icons directly with a definition object
-											//! ie import { faArrowRight } from '@fortawesome/free-solid-svg-icons';
-											<fa-icon def={iconObj} size="xl" />
-										) : (
-											//! Or  you can dynamically load the icon with its name.
-											//! ie icon={'arrow-right'}
-											<fa-icon icon={iconObj.iconName} size="xl" />
-										)}
+										<nowcomponents-fa-icon def={iconObj} size="xl" />
 									</div>
 									<div className="icon-footer">
 										<span>{iconObj.iconName}</span>


### PR DESCRIPTION
Changes:
- Added ability to set prefix in constants.js file
- Removed async as it adds a huge amount of compile time
- Removed host specific styling, **this was missing from the last PR**
- Added componentId as property to set custom ids

![image](https://user-images.githubusercontent.com/2008821/95680551-8e047480-0ba8-11eb-81a6-2e4562c8ccef.png)

The ability to set the prefix in one single file should make setting this up for personal projects and deployments much easier.